### PR TITLE
fix: keep unmapped source concepts in stratified code counts

### DIFF
--- a/inst/sql/sql_server/appendToStratrifiedCodeCountsTable.sql
+++ b/inst/sql/sql_server/appendToStratrifiedCodeCountsTable.sql
@@ -58,7 +58,9 @@ FROM (
                 vo.visit_source_concept_id = vmap.visit_source_concept_id
 }
         WHERE
-                t.@concept_id_field != 0
+                -- keep events even when the standard concept is unmapped (concept_id = 0)
+                -- as long as the source concept is known (e.g. NOMESCO procedure codes)
+                t.@concept_id_field != 0 OR t.@maps_to_concept_id_field != 0
 ) ccm
 GROUP BY
         ccm.concept_id,

--- a/inst/sql/sql_server/createCodeCountsTable.sql
+++ b/inst/sql/sql_server/createCodeCountsTable.sql
@@ -33,6 +33,8 @@ temp_concept_ancestor AS (
          concept_id AS concept_id, 
          SUM(record_counts) AS record_counts
      FROM @resultsDatabaseSchema.@stratifiedCodeCountsTable
+     -- skip unmapped events, which are counted under their source concept in the branch below
+     WHERE concept_id != 0
      GROUP BY
          concept_id
 

--- a/tests/testthat/test-createCodeCountsTable.R
+++ b/tests/testthat/test-createCodeCountsTable.R
@@ -538,3 +538,172 @@ test_that("createCodeCountsTables works stratified by visit_group_concept_id", {
     dplyr::pull(n) |>
     expect_equal(0)
 })
+
+
+test_that("stratified table keeps source concepts with no standard concept (concept_id = 0)", {
+  # Self-contained regression test: events whose standard concept is unmapped
+  # (concept_id = 0) but whose source concept is known (e.g. NOMESCO procedure
+  # codes) must NOT be dropped. They should land in the stratified table under
+  # maps_to_concept_id, and flow through to code_counts as the source concept.
+  # Runs on a throw-away SQLite CDM, so it does not need a full CDM database.
+
+  pathToSqlite <- tempfile(fileext = ".sqlite")
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = pathToSqlite
+  )
+  connection <- DatabaseConnector::connect(connectionDetails)
+  withr::defer({
+    DatabaseConnector::disconnect(connection)
+    unlink(pathToSqlite)
+  })
+
+  cdmDatabaseSchema <- "main"
+  resultsDatabaseSchema <- "main"
+
+  # - Minimal OMOP fixtures: one mapped event and one unmapped-source event
+  DatabaseConnector::insertTable(
+    connection,
+    tableName = "person",
+    data = tibble::tibble(person_id = 1L, gender_concept_id = 8507L, year_of_birth = 1980L),
+    dropTableIfExists = TRUE, createTable = TRUE, tempTable = FALSE
+  )
+  DatabaseConnector::insertTable(
+    connection,
+    tableName = "observation_period",
+    data = tibble::tibble(
+      person_id = 1L,
+      observation_period_start_date = "2000-01-01",
+      observation_period_end_date = "2030-01-01"
+    ),
+    dropTableIfExists = TRUE, createTable = TRUE, tempTable = FALSE
+  )
+  DatabaseConnector::insertTable(
+    connection,
+    tableName = "condition_occurrence",
+    data = tibble::tibble(
+      person_id = c(1L, 1L),
+      condition_concept_id = c(320128L, 0L), # second row is unmapped
+      condition_source_concept_id = c(44831230L, 2000999L), # source known in both
+      condition_start_date = c("2010-05-01", "2011-06-01"),
+      visit_occurrence_id = c(NA_integer_, NA_integer_)
+    ),
+    dropTableIfExists = TRUE, createTable = TRUE, tempTable = FALSE
+  )
+  # concept table needed by createCodeCountsTable (TEMP self-ancestor)
+  DatabaseConnector::insertTable(
+    connection,
+    tableName = "concept",
+    data = tibble::tibble(concept_id = c(320128L, 44831230L, 2000999L, 0L)),
+    dropTableIfExists = TRUE, createTable = TRUE, tempTable = FALSE
+  )
+  DatabaseConnector::executeSql(
+    connection,
+    "CREATE TABLE main.concept_ancestor (
+       ancestor_concept_id INTEGER,
+       descendant_concept_id INTEGER,
+       min_levels_of_separation INTEGER,
+       max_levels_of_separation INTEGER
+     );",
+    progressBar = FALSE, reportOverallTime = FALSE
+  )
+
+  domain <- tibble::tribble(
+    ~domain_id  , ~table_name            , ~concept_id_field      , ~date_field            , ~maps_to_concept_id_field     ,
+    "Condition" , "condition_occurrence" , "condition_concept_id" , "condition_start_date" , "condition_source_concept_id"
+  )
+
+  # - Build the stratified table exactly as createStratifiedCodeCountsTable does
+  stratifiedCodeCountsTable <- "stratified_code_counts_test_nomesco"
+  createSql <- SqlRender::render(
+    "DROP TABLE IF EXISTS @resultsDatabaseSchema.@stratifiedCodeCountsTable;
+     CREATE TABLE @resultsDatabaseSchema.@stratifiedCodeCountsTable (
+       concept_id INTEGER,
+       maps_to_concept_id INTEGER,
+       visit_group_concept_id INTEGER,
+       calendar_year INTEGER,
+       gender_concept_id INTEGER,
+       age_decile INTEGER,
+       record_counts INTEGER
+     )",
+    resultsDatabaseSchema = resultsDatabaseSchema,
+    stratifiedCodeCountsTable = stratifiedCodeCountsTable
+  )
+  DatabaseConnector::executeSql(
+    connection, SqlRender::translate(createSql, targetDialect = connection@dbms),
+    progressBar = FALSE, reportOverallTime = FALSE
+  )
+
+  appendSql <- SqlRender::readSql(
+    system.file("sql", "sql_server", "appendToStratrifiedCodeCountsTable.sql", package = "ROMOPAPI")
+  )
+  appendSql <- SqlRender::render(
+    appendSql,
+    stratifiedCodeCountsTable = stratifiedCodeCountsTable,
+    cdmDatabaseSchema = cdmDatabaseSchema,
+    resultsDatabaseSchema = resultsDatabaseSchema,
+    table_name = domain$table_name,
+    concept_id_field = domain$concept_id_field,
+    date_field = domain$date_field,
+    maps_to_concept_id_field = domain$maps_to_concept_id_field,
+    visit_group_concept_ids = "0"
+  )
+  DatabaseConnector::executeSql(
+    connection, SqlRender::translate(appendSql, targetDialect = connection@dbms),
+    progressBar = FALSE, reportOverallTime = FALSE
+  )
+
+  stratified <- DatabaseConnector::renderTranslateQuerySql(
+    connection,
+    "SELECT concept_id, maps_to_concept_id, record_counts
+       FROM @resultsDatabaseSchema.@stratifiedCodeCountsTable",
+    resultsDatabaseSchema = resultsDatabaseSchema,
+    stratifiedCodeCountsTable = stratifiedCodeCountsTable
+  ) |>
+    tibble::as_tibble()
+  names(stratified) <- tolower(names(stratified))
+
+  # the unmapped-source event is kept, tagged concept_id = 0 / source id
+  stratified |>
+    dplyr::filter(concept_id == 0 & maps_to_concept_id == 2000999) |>
+    nrow() |>
+    expect_equal(1)
+  # the mapped event is still there
+  stratified |>
+    dplyr::filter(concept_id == 320128) |>
+    nrow() |>
+    expect_equal(1)
+
+  # - Aggregate to code_counts and check the source concept surfaces, no phantom 0
+  codeCountsTable <- "code_counts_test_nomesco"
+  ccSql <- SqlRender::readSql(
+    system.file("sql", "sql_server", "createCodeCountsTable.sql", package = "ROMOPAPI")
+  )
+  ccSql <- SqlRender::render(
+    ccSql,
+    cdmDatabaseSchema = cdmDatabaseSchema,
+    resultsDatabaseSchema = resultsDatabaseSchema,
+    codeCountsTable = codeCountsTable,
+    stratifiedCodeCountsTable = stratifiedCodeCountsTable
+  )
+  DatabaseConnector::executeSql(
+    connection, SqlRender::translate(ccSql, targetDialect = connection@dbms),
+    progressBar = FALSE, reportOverallTime = FALSE
+  )
+
+  codeCounts <- DatabaseConnector::renderTranslateQuerySql(
+    connection,
+    "SELECT concept_id FROM @resultsDatabaseSchema.@codeCountsTable",
+    resultsDatabaseSchema = resultsDatabaseSchema,
+    codeCountsTable = codeCountsTable
+  ) |>
+    tibble::as_tibble()
+  names(codeCounts) <- tolower(names(codeCounts))
+
+  # source concept is counted
+  expect_true(2000999 %in% codeCounts$concept_id)
+  # mapped standard concept is still counted
+  expect_true(320128 %in% codeCounts$concept_id)
+  # unmapped events are not lumped into a phantom concept_id = 0
+  expect_false(0 %in% codeCounts$concept_id)
+})


### PR DESCRIPTION
Events whose standard concept is unmapped (concept_id = 0) but whose source concept is known (e.g. NOMESCO procedure codes) were dropped by the WHERE t.@concept_id_field != 0 filter, so they never reached the stratified table and were missing from code counts.

- appendToStratrifiedCodeCountsTable.sql: keep events when either the standard or the source concept is non-zero.
- createCodeCountsTable.sql: skip concept_id = 0 in the standard-concept branch so unmapped events are counted only under their source concept and do not form a phantom concept_id = 0 aggregate.
- add self-contained SQLite regression test covering both files.