### PR TITLE
ci: add Docker Hub publish workflow and scope R-CMD-check to package paths

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,8 +3,21 @@
 on:
   push:
     branches: [main, master]
+    paths: &r-package-paths
+      - 'R/**'
+      - 'man/**'
+      - 'tests/**'
+      - 'inst/**'
+      - 'vignettes/**'
+      - 'DESCRIPTION'
+      - 'NAMESPACE'
+      - 'renv.lock'
+      - '.Rbuildignore'
+      - '.Rprofile'
+      - '.github/workflows/R-CMD-check.yaml'
   pull_request:
     branches: [main, master, development]
+    paths: *r-package-paths
   schedule:
     - cron: '0 5 * * 0' # every Sunday at 5am UTC
 

--- a/.github/workflows/docker-publish-dev.yaml
+++ b/.github/workflows/docker-publish-dev.yaml
@@ -1,0 +1,39 @@
+# Build the Docker image and push it to Docker Hub on merge to development.
+# A push to `development` is what a merged PR produces, so this runs once the PR lands.
+on:
+  push:
+    branches: [development]
+
+name: docker-publish-dev.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  docker-publish-dev:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # The Dockerfile installs the DatabaseConnector fork from GitHub, so it
+      # needs a PAT passed as the `build_github_pat` build secret. The default
+      # GITHUB_TOKEN is enough for these public installs.
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: javiergrata/romopapi:dev
+          secrets: |
+            build_github_pat=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds continuous delivery of the container image and reduces noise from the
existing R CMD check. On merge to `development` the Dockerfile is built and
pushed to Docker Hub as `javiergrata/romopapi:dev`, and R-CMD-check now only
runs when R-package files actually change.

## Changes

- Add `.github/workflows/docker-publish-dev.yaml`: on push to `development`
  (i.e. a merged PR), build the Dockerfile for `linux/amd64` and push
  `javiergrata/romopapi:dev` to Docker Hub. Uses `docker/login-action` with
  `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets and passes `GITHUB_TOKEN` as
  the `build_github_pat` build secret so the DatabaseConnector fork installs.
- Scope `R-CMD-check.yaml` with `paths:` filters so it only triggers on changes
  to R sources, docs, tests, `inst/`, `vignettes/`, package metadata
  (`DESCRIPTION`, `NAMESPACE`, `renv.lock`), build config, or the workflow
  itself — doc/Docker/CI-only edits no longer trigger a full check.

## Testing

`devtools::check()` — clean: 0 errors, 0 warnings. Remaining 6 NOTES are
pre-existing (tidyverse NSE "no visible binding" notes and one Rd line-width
note) and unrelated to these CI-only changes.

## Setup required before this runs

Add repo secrets `DOCKERHUB_USERNAME` (`javiergrata`) and `DOCKERHUB_TOKEN`
(a Docker Hub access token with Read & Write scope), or the Docker Hub login
step will fail.